### PR TITLE
Fix JWT filter user lookup

### DIFF
--- a/src/main/java/com/pianomastr64/usermanagement/security/JwtAuthFilter.java
+++ b/src/main/java/com/pianomastr64/usermanagement/security/JwtAuthFilter.java
@@ -39,9 +39,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             }
             
             Long id = jwtUtil.extractId(token);
-            
+
             com.pianomastr64.usermanagement.user.User user = repo.findById(id)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+                .orElse(null);
+            if (user == null) {
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "User not found");
+                return;
+            }
             
             UserDetails userDetails = User
                 .withUsername(id.toString())


### PR DESCRIPTION
## Summary
- avoid throwing a RuntimeException in `JwtAuthFilter`
- return HTTP 401 when token corresponds to a nonexistent user

## Testing
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM)*
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6840abec505883219087c849361ab3a8